### PR TITLE
Fixes #2

### DIFF
--- a/server_advertiser/ServerAdvertiser.gd
+++ b/server_advertiser/ServerAdvertiser.gd
@@ -20,6 +20,7 @@ func _enter_tree():
 		broadcastTimer.connect("timeout", self, "broadcast") 
 		
 		socketUDP = PacketPeerUDP.new()
+		socketUDP.set_broadcast_enabled(true)
 		socketUDP.set_dest_address('255.255.255.255', broadcastPort)
 
 func broadcast():


### PR DESCRIPTION
`socketUDP.set_broadcast_enabled(true)` is required in godot 3.2 to work